### PR TITLE
Disable the extension on YouTube Music

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -30,6 +30,10 @@
       ],
       "matches": [
         "*://*.youtube.com/*"
+      ],
+      "exclude_matches": [
+        "*://music.youtube.com/*",
+        "*://*.music.youtube.com/*"
       ]
     }
   ],


### PR DESCRIPTION
I updated the `manifest.json` and left every other thing unchanged.

I disabled the extension on YouTube Music. ("*://music.youtube.com/*", "*://*.music.youtube.com/*")

Your extension works fine on YouTube.

But it will cause a double audio bug on YouTube Music, and this bug always happens.

I think the simplest way to solve the problem is to exclude the YouTube Music website.

YouTube banned all adblockers, but YouTube Music didn't. Users can block the ads from YouTube Music easily by using some famous adblockers in the Chrome web store if they want.

Maybe you need to double-check and add something to your extension if you merged this pull request.

I have tested the modified extension, and it works fine on my PC without the double audio bug on YouTube Music.

Thanks!