### PR TITLE
Fix youtube-reload

### DIFF
--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -146,6 +146,7 @@ const checkAndStartActions = () => {
         "youtube-errors",
         "youtube-recommendations",
         "youtube-continue-watching",
+        "youtube-reload",
       ])
       .then((settings) => {
         startActionsInterval(settings);


### PR DESCRIPTION
“youtube-reload” setting was missing, so it was always falsy and YT videos got reloaded regardless of plugin settings