### PR TITLE
add shorts reel blocking in mobile feed below video

### DIFF
--- a/scripts/youtube.js
+++ b/scripts/youtube.js
@@ -48,12 +48,16 @@ const hideYoutubeShorts = () => {
   const shortsHistoryPage = document.querySelectorAll(
     "ytd-reel-shelf-renderer",
   );
+  const shortsReelFeedMobile = document.querySelectorAll(
+    "ytm-reel-shelf-renderer",
+  );
   const shortsSidebar = document.querySelector('[title="Shorts"]');
   const shortsBottomMobile = document.querySelector('.pivot-shorts');
 
   shortsHomePage.forEach((item) => item.remove());
   shortsHomePageMobile.forEach((item) => item.remove());
   shortsHistoryPage.forEach((item) => item.remove());
+  shortsReelFeedMobile.forEach((item) => item.remove());
 
   if (shortsSidebar) {
     shortsSidebar.remove();


### PR DESCRIPTION
In my last PR, I missed the fact that Shorts are also suggested in the mobile feed below the playing video (meaning on the /watch page) as Shorts reels. These are `ytm-reel-shelf-renderer` elements (note the "m", not the same as the `ytd-` elements; I assume they correspond to "mobile" and "desktop"). 

This PR adds the code to remove these as well.